### PR TITLE
Fixed an issue where the status_frame could become too small

### DIFF
--- a/simpleguitk/frame.py
+++ b/simpleguitk/frame.py
@@ -37,7 +37,8 @@ class Frame(object):
         self._control_frame.grid(row=0, column=0, padx=5, pady=5)
 
     def _input_init(self):
-        status_frame = tkinter.Frame(self._root)
+        status_frame = tkinter.Frame(self._root, width=120, height=85)
+        status_frame.pack_propagate(0)
         canvas_widget = self._canvas._get_widget()
         self._input = InputAdapter(status_frame, self._root, canvas_widget)
         status_frame.grid(row=1, column=0, sticky=(tkinter.W, tkinter.E),


### PR DESCRIPTION
Causes it to pop sporadically when the input text was too large.

Ex. 'down down' when pressing down in the keydown handler in my Pong game.

Pull my repo at github.com/CardenB/pyGames and run Pong.py. Use the down arrow. The screen pops back and forth sporadically.
