### PR TITLE
`plot_lines` will fail if no legends are given.

### DIFF
--- a/simpleplot/plot.py
+++ b/simpleplot/plot.py
@@ -12,7 +12,7 @@ except ImportError:
 
 
 def plot_lines(framename, width, height, xlabel, ylabel, datasets,
-               points=False, legends=None):
+               points=False, legends=[]):
     matplotlib.pyplot.title(framename)
     matplotlib.pyplot.xlabel(xlabel)
     matplotlib.pyplot.ylabel(ylabel)


### PR DESCRIPTION
Default value makes function function fail.

Example of function call could be find at line 70 in [new course example](http://www.codeskulptor.org/#poc_mystery_plot.py). 
